### PR TITLE
small bug fixed

### DIFF
--- a/asr/wenet/bin/recognize_wav.py
+++ b/asr/wenet/bin/recognize_wav.py
@@ -242,7 +242,7 @@ def main():
                 last_batch_num_feats = chunk_size * last_batch_size
                 # Apply padding if needed
                 pad_amt = last_batch_num_feats - feats_batch.shape[1]
-                if pad_amt > 0:
+                if pad_amt >= 0:
                     feats_lengths = torch.tensor(
                         [chunk_size] * last_batch_size, dtype=torch.int32
                     )


### PR DESCRIPTION
This is a very unlikely bug, but I encountered that this error occurs when I enter the length of the feat that is exactly an integer multiple of the chunk_size but not an integer multiple of the batch_size, as follows:
assume：chunk_size=2051， batch_size = 16
when the input infeats shape:[1, 2051, test_conf["fbank_conf"]["num_mel_bins"]]（or something else that is an integer multiple of the chunk_size on dimension 1, but not an input of an integer multiple of chunk_size*batch_size）
the final feats_batch shape will be [1, 2051,  test_conf["fbank_conf"]["num_mel_bins"]], but the feats_lengths shape is [16]，This results in a mismatch of shapes on dimension 0